### PR TITLE
Changes for ghc 7.6

### DIFF
--- a/cabal-file-th.cabal
+++ b/cabal-file-th.cabal
@@ -20,7 +20,7 @@ source-repository head
 Library
   Exposed-modules:   Distribution.PackageDescription.TH
   Build-depends:     base >= 4 && < 5,
-                     Cabal >= 1.10 && < 1.15,
+                     Cabal >= 1.10 && < 1.17,
                      directory,
                      template-haskell
   Ghc-options: -Wall


### PR DESCRIPTION
Need to admit Cabal 1.16. Seems to build.
