### PR TITLE
Remove upper Cabal bound

### DIFF
--- a/cabal-file-th.cabal
+++ b/cabal-file-th.cabal
@@ -20,7 +20,7 @@ source-repository head
 Library
   Exposed-modules:   Distribution.PackageDescription.TH
   Build-depends:     base >= 4 && < 5,
-                     Cabal >= 1.10 && < 1.17,
+                     Cabal >= 1.10,
                      directory,
                      template-haskell
   Ghc-options: -Wall


### PR DESCRIPTION
Fixes compilation for users with Cabal >= 1.17.

The part of the Cabal API used by this package seems to be very stable.
