### PR TITLE
Use readGenericPackageDescription instead of readPackageDescription.

### DIFF
--- a/cabal-file-th.cabal
+++ b/cabal-file-th.cabal
@@ -1,5 +1,5 @@
 Name:                cabal-file-th
-Version:             0.2.5
+Version:             0.2.6
 Synopsis:            Template Haskell expressions for reading fields from a project's cabal file.
 Description:         Template Haskell expressions for reading fields from a project's cabal file.
 Homepage:            http://github.com/nkpart/cabal-file-th


### PR DESCRIPTION
Distribution.PackageDescription.Parse (readPackageDescription) was removed in Cabal 2.2.0.0.

fixes #8