### PR TITLE
Fixes for Cabal-3.0.0.0

### DIFF
--- a/Distribution/PackageDescription/TH.hs
+++ b/Distribution/PackageDescription/TH.hs
@@ -20,8 +20,14 @@ import Distribution.PackageDescription
 import Distribution.Package
 import Distribution.Version
 
+-- Distribution.Text is deprecated and Distribution.Compat.ReadP
+-- was removed in Cabal-3.0.0.0
+#if MIN_VERSION_Cabal(3,0,0)
+import Distribution.Pretty
+#else
 import Distribution.Text
 import Distribution.Compat.ReadP
+#endif
 import Distribution.Verbosity (Verbosity, silent)
 import Text.PrettyPrint
 import System.Directory (getCurrentDirectory, getDirectoryContents)
@@ -42,11 +48,17 @@ readPkgDesc :: Verbosity -> FilePath -> IO GenericPackageDescription
 
 newtype DocString = DocString String
 
+-- Text class was removed in Cabal-3.0.0.0
+#if MIN_VERSION_Cabal(3,0,0)
+instance Pretty DocString where
+  pretty (DocString s) =  text s
+#else
 instance Text DocString where
   parse = DocString `fmap` (readS_to_P read)
   disp (DocString s) = text s
+#endif
 
--- | Provides a Text instance for String, allowing text fields to be used
+-- | Provides a Pretty instance for String, allowing text fields to be used
 --   in `packageVariable`. Use it composed with an accessor, eg.
 --       packageVariable (packageString . copyright)
 packageString :: String -> DocString
@@ -55,17 +67,31 @@ packageString = DocString
 -- | Renders the package variable specified by the function.
 -- The cabal file interrogated is the first one that is found 
 -- in the current working directory.
+
+#if MIN_VERSION_Cabal(3,0,0)
+packageVariable :: Pretty a => (PackageDescription -> a) -> Q Exp
+#else
 packageVariable :: Text a => (PackageDescription -> a) -> Q Exp
+#endif
 packageVariable = renderField currentPackageDescription
 
 -- | Renders the package variable specified by the function, from a cabal file
 -- and the given path.
+#if MIN_VERSION_Cabal(3,0,0)
+packageVariableFrom :: Pretty a => FilePath -> (PackageDescription -> a) -> Q Exp
+#else
 packageVariableFrom :: Text a => FilePath -> (PackageDescription -> a) -> Q Exp
+#endif
 packageVariableFrom s = renderField $ fmap packageDescription (readPkgDesc silent s)
 
 ------
+#if MIN_VERSION_Cabal(3,0,0)
+renderField :: Pretty b => IO a -> (a -> b) -> Q Exp
+renderField pd f = renderFieldS pd (prettyShow . f)
+#else
 renderField :: Text b => IO a -> (a -> b) -> Q Exp
 renderField pd f = renderFieldS pd (display . f)
+#endif
 
 renderFieldS :: IO a -> (a -> String) -> Q Exp
 renderFieldS pd f = runIO pd >>= stringE . f


### PR DESCRIPTION
Use `Distribution.Pretty` instead of `Distribution.Text` and `Distribution.Compat.ReadP` which were deprecated and removed, respectively, in Cabal-3.0.0.0.

fixes #10