### PR TITLE
Upkeep and GHC 9.4 compatibility.

### DIFF
--- a/Distribution/PackageDescription/TH.hs
+++ b/Distribution/PackageDescription/TH.hs
@@ -21,7 +21,11 @@ module Distribution.PackageDescription.TH (
     ) where
 
 import Distribution.PackageDescription 
+#if MIN_VERSION_Cabal(3,4,1)
+import Distribution.Package ()
+#else
 import Distribution.Package
+#endif
 import Distribution.Version
 
 -- Distribution.Text is deprecated and Distribution.Compat.ReadP
@@ -38,10 +42,14 @@ import System.Directory (getCurrentDirectory, getDirectoryContents)
 import Data.List (isSuffixOf)
 import Language.Haskell.TH (Q, Exp, stringE, runIO)
 
+-- readGenericPackageDescription was moved to a different module in Cabal-3.8.1.0
 -- readPackageDescription was deprecated by readGenericPackageDescription
--- which was introduced in Cabal-2.0.0.2.
--- readPackageDescription was removed in Cabal-2.2.0.0
-#if MIN_VERSION_Cabal(2,2,0)
+-- which was introduced in Cabal-2.0.0.2
+-- readPackageDescription was removed in Cabal-2.2.0.0.
+#if MIN_VERSION_Cabal(3,8,1)
+import Distribution.Simple.PackageDescription (readGenericPackageDescription)
+readPkgDesc = readGenericPackageDescription
+#elif MIN_VERSION_Cabal(2,2,0)
 import Distribution.PackageDescription.Parsec (readGenericPackageDescription)
 readPkgDesc = readGenericPackageDescription
 #else

--- a/cabal-file-th.cabal
+++ b/cabal-file-th.cabal
@@ -1,5 +1,5 @@
 Name:                cabal-file-th
-Version:             0.2.7
+Version:             0.2.8
 Synopsis:            Template Haskell expressions for reading fields from a project's cabal file.
 Description:         Template Haskell expressions for reading fields from a project's cabal file.
 Homepage:            http://github.com/nkpart/cabal-file-th

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,8 +1,12 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Main where
 
 import Distribution.PackageDescription.TH
 import Control.Monad (when)
+#if MIN_VERSION_Cabal(3,2,1)
+import Distribution.Utils.ShortText
+#endif
 
 main :: IO ()
 main = do
@@ -12,7 +16,11 @@ main = do
 
   putStrLn $ "This package is version " ++ $(packageVariable (pkgVersion . package))
   let testVersion = $(packageVariableFrom "test/test-version-interp.cabal" (pkgVersion . package))
+#if MIN_VERSION_Cabal(3,2,1)
+      testCopyright = $(packageVariableFrom "test/test-version-interp.cabal" (packageString . fromShortText . copyright))
+#else
       testCopyright = $(packageVariableFrom "test/test-version-interp.cabal" (packageString . copyright))
+#endif
   simpleAssert "version" testVersion "5.5.5"
   simpleAssert "copyright" testCopyright "(c) 1953 Gumby"
 


### PR DESCRIPTION
Minor fixes to allow GHC 9.4.

Also fixes tests, broken since GHC 8.10.
I tested the latest minor releases all the way back to GHC 8.8.4, the tests are passing and there are no warnings.

Fixes #13.

Cheers :)